### PR TITLE
Support empty table cell

### DIFF
--- a/sphinxcontrib/reviewbuilder/writer.py
+++ b/sphinxcontrib/reviewbuilder/writer.py
@@ -349,6 +349,14 @@ class ReVIEWTranslator(TextTranslator):
 
         self.add_text(u'//table[%s][%s]{%s' % (label, title, self.nl))
 
+    def visit_entry(self, node):
+        if len(node) == 0:
+            # Fill single-dot ``.`` for empty table cells
+            self.add_text('.')
+            raise nodes.SkipNode
+        else:
+            TextTranslator.visit_entry(self, node)
+
     def depart_row(self, node):
         self.add_text(self.nl)
 

--- a/tests/review_test.py
+++ b/tests/review_test.py
@@ -114,6 +114,7 @@ def test_table(app, status, warnings):
     expected = [
         '//table[compact-label][]{\nA\tnot A\n------------\nFalse\tTrue\nTrue\tFalse\n//}',
         '//table[tablename][Frozen Delights!]{\nTreat\tQuantity\tDescription',
+        '//table[empty-cell][]{\nA\tnot A\n------------\nFalse\t.\nTrue\tFalse\n//}',
     ]
 
     for e in expected:

--- a/tests/root/table.txt
+++ b/tests/root/table.txt
@@ -29,3 +29,16 @@ csv-table
    "Crunchy Frog", 1.49, "If we took the bones out, it wouldn't be
    crunchy, now would it?"
    "Gannet Ripple", 1.99, "On a stick!"
+
+
+table having empty cell
+-----------------------
+
+.. _empty-cell:
+
+=====  =====
+  A    not A
+=====  =====
+False
+True   False
+=====  =====


### PR DESCRIPTION
Re:VIEW expects empty table cell is represented as single dot.

>表の各列のセル間は「1つ」のタブで区切ります。空白のセルには「.」と書きます。セルの先頭の「.」は削除されるので、先頭文字が「.」の場合は「.」をもう1つ余計に付けてください。たとえば「.」という内容のセルは「..」と書きます。