### PR TITLE
Make "guess" as a default of code-block language

### DIFF
--- a/sphinxcontrib/reviewbuilder/writer.py
+++ b/sphinxcontrib/reviewbuilder/writer.py
@@ -243,7 +243,7 @@ class ReVIEWTranslator(TextTranslator):
         # TODO: remove highlight args
         self.new_state(0)
 
-        lang = node.get('language', '')
+        lang = node.get('language', 'guess')
 
         if lang == "bash":  # use cmd
             self.add_text('//cmd{' + self.nl)


### PR DESCRIPTION
In "Sphinxをはじめよう", we use it by default. I think this might help users.