### PR TITLE
Add new config value: review_keep_comments

### DIFF
--- a/sphinxcontrib/reviewbuilder/reviewbuilder.py
+++ b/sphinxcontrib/reviewbuilder/reviewbuilder.py
@@ -122,3 +122,4 @@ class ReVIEWBuilder(TextBuilder):
 def setup(app):
     app.add_builder(ReVIEWBuilder)
     app.add_config_value('review_catalog_file', '', 'review')
+    app.add_config_value('review_keep_comments', False, 'review')

--- a/sphinxcontrib/reviewbuilder/writer.py
+++ b/sphinxcontrib/reviewbuilder/writer.py
@@ -435,6 +435,9 @@ class ReVIEWTranslator(TextTranslator):
         self.end_state()
 
     def visit_comment(self, node):
+        if self.builder.config.review_keep_comments is False:
+            raise nodes.SkipNode
+
         for c in node.astext().splitlines():
             self.add_text('#@# %s%s' % (c, self.nl))
 

--- a/tests/review_test.py
+++ b/tests/review_test.py
@@ -31,8 +31,6 @@ def test_basic(app, status, warning):
         u'@<href>{https://github.com/kmuto/review/blob/master/doc/format.rdoc}',
         u'ここは@<fn>{f1}脚注@<fn>{f2}',
         u'//footnote[f2][脚注2は@<i>{インライン}@<b>{要素}を@<href>{https://github.com/kmuto/review,含みます}]',
-        u'#@# コメントです',
-        u'#@# コメントブロック1\n#@# コメントブロック2',
         u'//raw[|html|<hr width=50 size=10>]',
         u'@<u>{下線}を引きます',
         u'索引@<hidx>{インデックス}インデックスを作ります',  # TODO: インデックス文字が入っている
@@ -41,6 +39,13 @@ def test_basic(app, status, warning):
     print(re)
     for e in expected:
         assert e in re
+
+    unexpected = [
+        u'#@# コメントです',
+        u'#@# コメントブロック1\n#@# コメントブロック2',
+    ]
+    for e in unexpected:
+        assert e not in re
 
 
 @pytest.mark.sphinx('review')
@@ -192,6 +197,21 @@ def test_reference(app, status, warning):
         u'numfig@<list>{code|なにもなしname}です',
         u'numfig@<chap>{basic}です',
         u'numfig@<hd>{basic|section-2}です',
+    ]
+
+    for e in expected:
+        assert e in re
+
+
+@pytest.mark.sphinx('review', confoverrides={'review_keep_comments': True})
+def test_keep_comments(app, status, warning):
+    app.builder.build_all()
+
+    re = (app.outdir / 'basic.re').text()
+
+    expected = [
+        u'#@# コメントです',
+        u'#@# コメントブロック1\n#@# コメントブロック2',
     ]
 
     for e in expected:


### PR DESCRIPTION
In Re:VIEW, comments are not allowed everywhere.  For example, it
is hard to write comments inside table, lists and so on.

This option make conversion more easiler and safer. I believe
users of this extensions don't want to modify Re:VIEW articles. So
I think this does not bring any problem for major case.