### PR TITLE
Add new config value: review_use_cmd_block

### DIFF
--- a/sphinxcontrib/reviewbuilder/reviewbuilder.py
+++ b/sphinxcontrib/reviewbuilder/reviewbuilder.py
@@ -123,3 +123,4 @@ def setup(app):
     app.add_builder(ReVIEWBuilder)
     app.add_config_value('review_catalog_file', '', 'review')
     app.add_config_value('review_keep_comments', False, 'review')
+    app.add_config_value('review_use_cmd_block', True, 'review')

--- a/sphinxcontrib/reviewbuilder/writer.py
+++ b/sphinxcontrib/reviewbuilder/writer.py
@@ -220,7 +220,7 @@ class ReVIEWTranslator(TextTranslator):
         # TODO: remove highlight args
         lang = node.get('language', 'guess')
 
-        if lang == "bash":  # use cmd
+        if lang == "bash" and self.builder.config.review_use_cmd_block:
             self.new_review_block('//cmd{')
             return
 

--- a/tests/review_test.py
+++ b/tests/review_test.py
@@ -217,3 +217,13 @@ def test_keep_comments(app, status, warning):
 
     for e in expected:
         assert e in re
+
+
+@pytest.mark.sphinx('review', confoverrides={'review_use_cmd_block': False})
+def test_review_use_cmd_block(app, status, warning):
+    app.builder.build_all()
+
+    re = (app.outdir / 'code.re').text()
+
+    expected = (u'//emlist[][bash]{\n$ cd /\n$ sudo rm -rf /\n//}')
+    assert expected in re


### PR DESCRIPTION
In some kind of books, authors want to use `list` or `emlist` for all literal_blocks whole of document. For example, our book "Sphinxをはじめよう" uses `emlist` always.
This option allows that.